### PR TITLE
Corrections for use within embedded systems

### DIFF
--- a/googletest/src/gtest-filepath.cc
+++ b/googletest/src/gtest-filepath.cc
@@ -303,7 +303,7 @@ bool FilePath::CreateDirectoriesRecursively() const {
     return false;
   }
 
-  if (pathname_.length() == 0 || this->DirectoryExists()) {
+  if (pathname_.length() == 0 || pathname_ == kCurrentDirectoryString || this->DirectoryExists()) {
     return true;
   }
 

--- a/googletest/src/gtest-internal-inl.h
+++ b/googletest/src/gtest-internal-inl.h
@@ -675,7 +675,6 @@ class GTEST_API_ UnitTestImpl {
   void AddTestInfo(internal::SetUpTestSuiteFunc set_up_tc,
                    internal::TearDownTestSuiteFunc tear_down_tc,
                    TestInfo* test_info) {
-#if GTEST_HAS_DEATH_TEST
     // In order to support thread-safe death tests, we need to
     // remember the original working directory when the test program
     // was first invoked.  We cannot do this in RUN_ALL_TESTS(), as
@@ -688,7 +687,6 @@ class GTEST_API_ UnitTestImpl {
       GTEST_CHECK_(!original_working_dir_.IsEmpty())
           << "Failed to get the current working directory.";
     }
-#endif  // GTEST_HAS_DEATH_TEST
 
     GetTestSuite(test_info->test_suite_name(), test_info->type_param(),
                  set_up_tc, tear_down_tc)

--- a/googletest/src/gtest.cc
+++ b/googletest/src/gtest.cc
@@ -183,9 +183,10 @@ static FILE* OpenFileForWriting(const std::string& output_file) {
   FilePath output_file_path(output_file);
   FilePath output_dir(output_file_path.RemoveFileName());
 
-  if (output_dir.CreateDirectoriesRecursively()) {
-    fileout = posix::FOpen(output_file.c_str(), "w");
+  if (!output_dir.CreateDirectoriesRecursively()) {
+    GTEST_LOG_(WARNING) << "Unable to create path to file \"" << output_file << "\"";
   }
+  fileout = posix::FOpen(output_file.c_str(), "w");
   if (fileout == nullptr) {
     GTEST_LOG_(FATAL) << "Unable to open file \"" << output_file << "\"";
   }


### PR DESCRIPTION
Avoid stack overflow in CreateDirectoriesRecursively
https://github.com/google/googletest/pull/4263

Allow CreateDirectoriesRecursively() to fail on report
https://github.com/google/googletest/pull/4264

Check for file system for current directory (custom version due to older googletest)
https://github.com/google/googletest/pull/4269
