### PR TITLE
Avoid stack overflow in CreateDirectoriesRecursively

### DIFF
--- a/googletest/src/gtest-filepath.cc
+++ b/googletest/src/gtest-filepath.cc
@@ -334,7 +334,7 @@ bool FilePath::CreateDirectoriesRecursively() const {
     return false;
   }
 
-  if (pathname_.length() == 0 || this->DirectoryExists()) {
+  if (pathname_.length() == 0 || pathname_ == kCurrentDirectoryString || this->DirectoryExists()) {
     return true;
   }
 


### PR DESCRIPTION
### Describe the issue

Asking google test to output to a non existing path, on a system with no notion of "./" being a path causes FilePath::CreateDirectoriesRecursively to end up in an infinite loop with stack overflow.

### Steps to reproduce the problem

Somewhat hard.
- Run on an embedded system with file support, but no concept on a current directory named "./".
- Ask google-test to output xml to a non existing path.
